### PR TITLE
Fix error code ordering

### DIFF
--- a/packf.h
+++ b/packf.h
@@ -86,9 +86,9 @@ enum
     PACKF_OUT_OF_BUF    = -1,
     PACKF_NOT_FORMAT    = -2,
     PACKF_NOT_MATCH     = -3,
-    PACKF_EXPECT_FORMAT = -3,
-    PACKF_BE_CUT_OFF    = -4,
-    PACKF_NULL_POINTER  = -5,
+    PACKF_EXPECT_FORMAT = -4,
+    PACKF_BE_CUT_OFF    = -5,
+    PACKF_NULL_POINTER  = -6,
 };
 
 /*


### PR DESCRIPTION
## Summary
- update `packf.h` so error codes map to the right message table indexes

## Testing
- `gcc -std=c99 -Wall -Wextra -pedantic -o test packf.c test.c`
- `./test | head -n 2`

------
https://chatgpt.com/codex/tasks/task_e_688b19e954588322a73a6bf5ef8d4d77